### PR TITLE
test: bumps versions and removes use of initMocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>fish.focus.uvms.maven</groupId>
         <artifactId>uvms-pom</artifactId>
-        <version>3.19</version>
+        <version>3.27</version>
         <relativePath />
     </parent>
     
@@ -16,7 +16,7 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <asset.model.version>6.8.29</asset.model.version>
+        <asset.model.version>6.8.35</asset.model.version>
         <uvms.common.version>4.1.15</uvms.common.version>
 
         <vessel.client.version>2.1.42</vessel.client.version>
@@ -44,7 +44,7 @@
             <artifactId>uvms-pom-java11-deps</artifactId>
             <type>pom</type>
             <scope>provided</scope>
-            <version>3.19</version>
+            <version>3.27</version>
         </dependency>
         <dependency>
             <groupId>fish.focus.uvms.asset</groupId>

--- a/src/test/java/se/havochvatten/unionvms/vessel/proxy/cache/message/TestVesselServiceBean.java
+++ b/src/test/java/se/havochvatten/unionvms/vessel/proxy/cache/message/TestVesselServiceBean.java
@@ -11,6 +11,7 @@ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more d
 copy of the GNU General Public License along with the IFDM Suite. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,6 +21,7 @@ import org.mockito.MockitoAnnotations;
 import se.havochvatten.unionvms.vessel.proxy.cache.bean.ParameterServiceBean;
 import se.havochvatten.unionvms.vessel.proxy.cache.bean.VesselServiceBean;
 import se.havochvatten.unionvms.vessel.proxy.cache.constant.ParameterKey;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -33,15 +35,20 @@ public class TestVesselServiceBean {
     @Mock
     private ParameterServiceBean parameterService;
 
-    private String nationsAsStringWithSpaces = " SWE , DN K, ESP , FIN";
-    private List<String> nations = Arrays.asList("SWE", "DNK", "ESP" , "FIN");
+    private final String nationsAsStringWithSpaces = " SWE , DN K, ESP , FIN";
+    private final List<String> nations = Arrays.asList("SWE", "DNK", "ESP" , "FIN");
 
+    private AutoCloseable openedMocks;
 
     @Before
     public void setup(){
-        MockitoAnnotations.initMocks(this);
+        openedMocks = MockitoAnnotations.openMocks(this);
         when(parameterService.getParameterValue(ParameterKey.NATIONAL_VESSEL_NATIONS)).thenReturn(nationsAsStringWithSpaces);
+    }
 
+    @After
+    public void closeMocks() throws Exception {
+        openedMocks.close();
     }
 
     @Test
@@ -49,5 +56,4 @@ public class TestVesselServiceBean {
         List<String> nationsFromDatabase = vesselServiceBean.getNationsFromDatabase();
         Assert.assertArrayEquals(nations.toArray(), nationsFromDatabase.toArray());
     }
-
 }


### PR DESCRIPTION
Changes from deprecated Mockito initMocks openMocks instead.

Bumps asset version to 6.8.35.